### PR TITLE
Prefer static function over constant

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ charset = utf-8
 
 [*.json]
 indent_size = 2
+
+[composer.json]
+indent_size = 4

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -30,3 +30,13 @@ jobs:
             - run: npm run build
 
             - run: npm test
+
+            - uses: shivammathur/setup-php@v2
+              with:
+                  php-version: 8.3
+                  tools: composer:v2
+                  ini-file: development
+
+            - run: composer install
+
+            - run: composer phpstan

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 node_modules/
 .idea
 .DS_Store
-build
 dist/
 build/
+vendor/

--- a/bin/populateLanguages.js
+++ b/bin/populateLanguages.js
@@ -23,21 +23,28 @@ fs.appendFileSync(
     " */\n" +
     "class Languages\n" +
     "{\n" +
-    "    /** @phpstan-var array<string, Language> */\n" +
-    "    const DATA = [\n"
+    "    /** @phpstan-return array<string, Language> */\n" +
+    "    public static function getData()\n" +
+    "    {\n" +
+    "        return [\n"
 );
 
 languagesJson.languages.forEach((language, i, array) => {
-    fs.appendFileSync(languagesFilePath,`        '${language.code}' => [\n`);
-    fs.appendFileSync(languagesFilePath,`            'code' => '${language.code}',\n`);
-    fs.appendFileSync(languagesFilePath,`            'english' => "${language.english_name}",\n`);
-    fs.appendFileSync(languagesFilePath,`            'local' => "${language.local_name.replace(/[""]/g, '')}",\n`);
-    fs.appendFileSync(languagesFilePath,`            'rtl' => ${language.rtl},\n`);
-    fs.appendFileSync(languagesFilePath,`            'country' => '${language.country_flag_code}',\n`);
-    fs.appendFileSync(languagesFilePath,`            'variant' => ${language.variant},\n`);
-    fs.appendFileSync(languagesFilePath,`        ]${i !== array.length-1 ? "," : ''}\n`);
+    fs.appendFileSync(languagesFilePath,`            '${language.code}' => [\n`);
+    fs.appendFileSync(languagesFilePath,`                'code' => '${language.code}',\n`);
+    fs.appendFileSync(languagesFilePath,`                'english' => "${language.english_name}",\n`);
+    fs.appendFileSync(languagesFilePath,`                'local' => "${language.local_name.replace(/[""]/g, '')}",\n`);
+    fs.appendFileSync(languagesFilePath,`                'rtl' => ${language.rtl},\n`);
+    fs.appendFileSync(languagesFilePath,`                'country' => '${language.country_flag_code}',\n`);
+    fs.appendFileSync(languagesFilePath,`                'variant' => ${language.variant},\n`);
+    fs.appendFileSync(languagesFilePath,`            ],\n`);
 });
-fs.appendFileSync(languagesFilePath, "    ];\n}");
+fs.appendFileSync(
+    languagesFilePath,
+    "        ];\n" +
+    "    }\n" +
+    "}\n"
+);
 
 // Populate Countries.php
 const countriesFilePath = "dist/Countries.php";
@@ -58,14 +65,21 @@ fs.appendFileSync(
     " */\n" +
     "class Countries\n" +
     "{\n" +
-    "    /** @phpstan-var array<string, Country> */\n" +
-    "    const DATA = [\n"
+    "    /** @phpstan-return array<string, Country> */\n" +
+    "    public static function getData()\n" +
+    "    {\n" +
+    "         return [\n"
 );
 
 CountriesJson.countries.forEach((country, i, array) => {
-    fs.appendFileSync(countriesFilePath,`        '${country.code}' => [\n`);
-    fs.appendFileSync(countriesFilePath,`            'code' => '${country.code}',\n`);
-    fs.appendFileSync(countriesFilePath,`            'name' => '${country.name}',\n`);
-    fs.appendFileSync(countriesFilePath,`        ]${i !== array.length-1 ? "," : ''}\n`);
+    fs.appendFileSync(countriesFilePath,`            '${country.code}' => [\n`);
+    fs.appendFileSync(countriesFilePath,`                'code' => '${country.code}',\n`);
+    fs.appendFileSync(countriesFilePath,`                'name' => '${country.name}',\n`);
+    fs.appendFileSync(countriesFilePath,`            ],\n`);
 });
-fs.appendFileSync(countriesFilePath, "    ];\n}");
+fs.appendFileSync(
+    countriesFilePath,
+    "         ];\n" +
+    "    }\n" +
+    "}\n"
+);

--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,18 @@
 {
-  "name": "weglot/languages",
-  "description": "A comprehensive dataset containing language codes and names compatible with Weglot.",
-  "type": "library",
-  "minimum-stability": "stable",
-  "license": "proprietary",
-  "autoload": {
-    "psr-4": {
-      "WeglotLanguages\\": "dist/"
+    "name": "weglot/languages",
+    "description": "A comprehensive dataset containing language codes and names compatible with Weglot.",
+    "type": "library",
+    "minimum-stability": "stable",
+    "license": "proprietary",
+    "autoload": {
+        "psr-4": {
+            "WeglotLanguages\\": "dist/"
+        }
+    },
+    "require-dev": {
+        "phpstan/phpstan": "1.11.*"
+    },
+    "scripts": {
+        "phpstan": "vendor/bin/phpstan"
     }
-  }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,77 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "a7921db514d89308c7ee52a56720b657",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.11.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "6adbd118e6c0515dd2f36b06cde1d6da40f1b8ec"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/6adbd118e6c0515dd2f36b06cde1d6da40f1b8ec",
+                "reference": "6adbd118e6c0515dd2f36b06cde1d6da40f1b8ec",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-24T07:01:22+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.6.0"
+}

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,0 +1,13 @@
+includes:
+    - vendor/phpstan/phpstan/conf/bleedingEdge.neon
+
+parameters:
+    level: 9
+    paths:
+        - dist/
+    exceptions:
+        check:
+            missingCheckedExceptionInThrows: true
+            tooWideThrowType: true
+        reportUncheckedExceptionDeadCatch: false
+        implicitThrows: false


### PR DESCRIPTION
On a un soucis avec phpstan (https://github.com/phpstan/phpstan/issues/10717) car les arrays de constantes sont trop gros.
Du coup phpstan simplifie l'array mais pas comme on veut. On peut pas override le behavior pour une constante.
Par contre si c'est une fonction, il utilise notre return type.
Du coup suffit de préférer des méthodes statiques plutot que des constantes.

En prime, je run phpstan sur nos fichiers php.