### PR TITLE
Fix/5886 Migrate incorrectly mapped language codes for Cebuano

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -889,7 +889,7 @@
       "variant": "false"
     },
     {
-      "code": "cb",
+      "code": "ceb",
       "english_name": "Cebuano",
       "local_name": "Sugbuanon",
       "rtl": "false",


### PR DESCRIPTION
Related to: https://github.com/weglot/core/issues/5886

Mais que pour le cebuano