### PR TITLE
Fix/5886 Migrate incorrectly mapped language codes

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -65,7 +65,7 @@
       "variant": "false"
     },
     {
-      "code": "pt-br",
+      "code": "br",
       "english_name": "Brazilian Portuguese",
       "local_name": "Português Brasileiro",
       "rtl": "false",
@@ -793,7 +793,7 @@
       "variant": "false"
     },
     {
-      "code": "zh-tw",
+      "code": "tw",
       "english_name": "Traditional Chinese",
       "local_name": "中文 (繁體)",
       "rtl": "false",
@@ -921,7 +921,7 @@
       "variant": "false"
     },
     {
-      "code": "fr-ca",
+      "code": "fc",
       "english_name": "French (Canada)",
       "local_name": "Français (Canada)",
       "rtl": "false",


### PR DESCRIPTION
Première tentative de blue green avec le changement de hm -> hmn et sa -> sr-latn.

Je passerai br -> pt-br, fc -> fr-ca et tw -> zh-tw dans un autre blue green